### PR TITLE
Add provider auto discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,12 @@
         "classmap": [
             "src/"
         ]
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Sineld\\BladeSet\\BladeSetServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
This addition allows Laravel 5.5+ to autodiscover the service provider (no manual setup is required)